### PR TITLE
[update] read string memory allocation optimization

### DIFF
--- a/iter_str.go
+++ b/iter_str.go
@@ -3,7 +3,13 @@ package jsoniter
 import (
 	"fmt"
 	"unicode/utf16"
+	"unsafe"
 )
+
+// bytesToString convert []byte to string
+func bytesToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
 
 // ReadString read string from iterator
 func (iter *Iterator) ReadString() (ret string) {
@@ -12,7 +18,7 @@ func (iter *Iterator) ReadString() (ret string) {
 		for i := iter.head; i < iter.tail; i++ {
 			c := iter.buf[i]
 			if c == '"' {
-				ret = string(iter.buf[iter.head:i])
+				ret = bytesToString(iter.buf[iter.head:i])
 				iter.head = i + 1
 				return ret
 			} else if c == '\\' {


### PR DESCRIPTION
#  memory allocation optimization
ReadString func exist too much alloc
 
## before optimze Test:
BenchmarkDecodeJsoniterStructMedium-4             195046              6399 ns/op
384 B/op         41 allocs/op 
by:  https://github.com/json-iterator/go-benchmark/blob/master/src/github.com/json-iterator/go-benchmark/benchmark_medium_payload_test.go 

## after optimze Test:
BenchmarkDecodeJsoniterStructMedium-4             219428              4998 ns/op
              32 B/op          2 allocs/op
by:  https://github.com/json-iterator/go-benchmark/blob/master/src/github.com/json-iterator/go-benchmark/benchmark_medium_payload_test.go
